### PR TITLE
fix_confirmation_run's_waypoint

### DIFF
--- a/waypoints/tsukuba/20230923/m2/20230923_Senior.yaml
+++ b/waypoints/tsukuba/20230923/m2/20230923_Senior.yaml
@@ -1,40 +1,39 @@
 waypoints:
-- point: {x: 4.09724, y: 0.504168, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 16.659, y: 1.14789, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 20.5776, y: 1.30268, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 28.2563, y: 1.64634, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 38.188038, y: 2.120696, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 48.40857, y: 2.561473, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 55.681401, y: 2.864508, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 60.337115, y: 0.302488, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 62.485907, y: -6.143885, z: 0, vel: 1, rad: 0.8, stop: false}
+- point: {x: 4.09724, y: 0.504168, z: 0, vel: 1, rad: 1.5, stop: false}
+- point: {x: 16.700848, y: 1.705895, z: 0, vel: 1, rad: 1.5, stop: false}
+- point: {x: 22.656569, y: 2.147059, z: 0, vel: 1, rad: 1.5, stop: false}
+- point: {x: 29.839331, y: 2.758199, z: 0, vel: 1, rad: 1.5, stop: false}
+- point: {x: 38.687338, y: 3.415821, z: 0, vel: 1, rad: 1.5, stop: false}
+- point: {x: 48.372319, y: 4.073444, z: 0, vel: 1, rad: 1.5, stop: false}
+- point: {x: 56.383353, y: 4.01366, z: 0, vel: 1, rad: 1.5, stop: false}
+- point: {x: 60.337115, y: 0.302488, z: 0, vel: 1, rad: 1.5, stop: false}
+- point: {x: 62.485907, y: -6.143885, z: 0, vel: 1, rad: 1.5, stop: false}
 - point: {x: 64.910184, y: -11.818898, z: 0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 68.877183, y: -12.590259, z: 0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 72.596244, y: -13.003488, z: 0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 76.590792, y: -12.893293, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 79.290555, y: -13.003488, z: 0, vel: 1, rad: 0.8, stop: false}
+- point: {x: 80.35213, y: -12.830639, z: 0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 81.384249, y: -14.050335, z: 0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 83.092262, y: -15.427765, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 85.433893, y: -16.144029, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 87.775525, y: -16.336869, z: 0, vel: 1, rad: 0.8, stop: false}
+- point: {x: 85.375453, y: -15.573047, z: 0, vel: 1, rad: 0.8, stop: false}
+- point: {x: 87.948912, y: -15.646575, z: 0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 90.475288, y: -16.639903, z: 0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 93.450537, y: -16.998035, z: 0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 96.921661, y: -17.631653, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 99.979556, y: -17.769396, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 102.789513, y: -17.796945, z: 0, vel: 1, rad: 0.8, stop: false}
+- point: {x: 100.375045, y: -19.617055, z: 0, vel: 1, rad: 0.8, stop: false}
+- point: {x: 102.948505, y: -19.102363, z: 0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 105.076101, y: -18.22123, z: 0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 107.367264, y: -16.761175, z: 0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 110.350672, y: -16.292848, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 114.014609, y: -16.7239, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 115.523289, y: -19.310208, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 115.95434, y: -23.405196, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 116.600917, y: -30.517543, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 117.247494, y: -38.491993, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 117.894071, y: -46.897494, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 118.756174, y: -55.734046, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 119.618276, y: -65.217176, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 120.264853, y: -75.777934, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 121.126956, y: -84.398961, z: 0, vel: 1, rad: 0.8, stop: false}
+- point: {x: 113.796018, y: -17.659821, z: 0, vel: 1, rad: 0.8, stop: false}
+- point: {x: 114.18043, y: -24.026653, z: 0, vel: 1, rad: 1.5, stop: false}
+- point: {x: 114.746465, y: -31.45136, z: 0, vel: 1, rad: 1.5, stop: false}
+- point: {x: 115.333031, y: -39.141904, z: 0, vel: 1, rad: 1.5, stop: false}
+- point: {x: 116.049947, y: -47.288667, z: 0, vel: 1, rad: 1.5, stop: false}
+- point: {x: 116.788586, y: -55.674402, z: 0, vel: 1, rad: 1.5, stop: false}
+- point: {x: 117.734571, y: -65.314874, z: 0, vel: 1, rad: 1.5, stop: false}
+- point: {x: 118.625978, y: -75.843104, z: 0, vel: 1, rad: 1.5, stop: false}
+- point: {x: 119.445108, y: -83.576655, z: 0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 116.372572, y: -89.126653, z: 0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 109.270148, y: -89.473113, z: 0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 104.747005, y: -86.123166, z: 0, vel: 1, rad: 0.8, stop: false}
@@ -66,33 +65,19 @@ waypoints:
 - point: {x: 22.346447, y: -94.664897, z: 0.0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 18.406542, y: -94.526527, z: 0.0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 16.850288, y: -93.879545, z: 0.0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 16.045933, y: -92.253348, z: 0.0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 15.836101, y: -89.962683, z: 0.0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 15.626269, y: -87.724475, z: 0.0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 15.556325, y: -85.223978, z: 0.0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 15.224091, y: -82.933313, z: 0.0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 14.979287, y: -80.362872, z: 0.0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 14.760712, y: -78.028492, z: 0.0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 14.533394, y: -75.510508, z: 0.0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 14.323562, y: -72.782693, z: 0.0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 13.868926, y: -70.142308, z: 0.0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 13.571664, y: -67.187175, z: 0.0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 13.344347, y: -64.389416, z: 0.0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 13.134515, y: -61.679087, z: 0.0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 12.714851, y: -58.74144, z: 0.0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 12.505019, y: -55.873737, z: 0.0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 12.295187, y: -52.883632, z: 0.0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 12.102841, y: -50.103359, z: 0.0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 11.638893, y: -46.960939, z: 0.0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 11.434119, y: -43.72179, z: 0.0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 11.21073, y: -40.389562, z: 0.0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 11.080419, y: -37.20626, z: 0.0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 10.85703, y: -33.967111, z: 0.0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 8.585902, y: -31.025815, z: 0.0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 5.988998, y: -29.769248, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 3.326939, y: -29.359701, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 0.385643, y: -28.987385, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: -2.890738, y: -29.006001, z: 0, vel: 1, rad: 0.8, stop: false}
+- point: {x: 11.914931, y: -52.937383, z: 0.0, vel: 1, rad: 0.8, stop: false}
+- point: {x: 11.288742, y: -47.023377, z: 0.0, vel: 1, rad: 0.8, stop: false}
+- point: {x: 10.175517, y: -40.691912, z: 0.0, vel: 1, rad: 0.8, stop: false}
+- point: {x: 6.809018, y: -33.868066, z: 0.0, vel: 1, rad: 0.8, stop: false}
+- point: {x: 3.148287, y: -28.898688, z: 0, vel: 1, rad: 0.8, stop: false}
+- point: {x: -2.730931, y: -28.585594, z: 0, vel: 1, rad: 0.8, stop: false}
 - point: {x: -7.116524, y: -28.652301, z: 0, vel: 1, rad: 0.8, stop: false}
 - point: {x: -12.738496, y: -29.080464, z: 0, vel: 1, rad: 0.8, stop: false}
 - point: {x: -17.280751, y: -29.341085, z: 0, vel: 1, rad: 0.8, stop: false}
@@ -100,10 +85,9 @@ waypoints:
 - point: {x: -34.374714, y: -35.791904, z: 0, vel: 1, rad: 0.8, stop: false}
 - point: {x: -38.994835, y: -38.941986, z: 0, vel: 1, rad: 0.8, stop: false}
 - point: {x: -44.717484, y: -39.414498, z: 0, vel: 1, rad: 0.8, stop: false}
-- point: {x: -50.781392, y: -39.388248, z: 0.0, vel: , rad: , stop: }
-- point: {x: -56.189033, y: -39.703256, z: 0.0, vel: , rad: , stop: }
+- point: {x: -50.781392, y: -39.388248, z: 0.0, vel: 1, rad: 0.8, stop: false}
 finish_pose:
   header: {seq: 0, stamp: 1666489211.5504568, frame_id: map}
   pose:
-    position: {x: -59.2588, y: -38.328, z: 0}
-    orientation: {x: 0.0, y: 0.0, z: 0.99999541274693, w: 0.00302894125019187}
+    position: {x: -54.555521, y: -39.802063, z: 0}
+    orientation: {x: 0.0, y: 0.0, z: -0.997553633922968, w: 0.06990527481586149}


### PR DESCRIPTION
## PR Type
<!--
Please select the type of changes you're introducing to the codebase:
-->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Overview
- つくばチャレンジ確認走行コースのwaypointの調整と, mapの上の不要な障害物の除去. 
<!--
Brief summary of the changes made in this PR.
-->

## Detail
1.つくばチャレンジ確認走行コースのwaypointの調整
- スタート直後のwaypointで右に寄っている部分を修正. 
- スタート直後と市役所裏にあるwaypointのradを0.8→1.5に緩和. 
- 市役所裏のwaypointを建物寄りに修正. 
- 市役所玄関のwaypoint数を減少. 

2.map上の不要な障害物の除去
- 環境地図作成時に映ってしまった障害物をgimpを用いて削除しました. 

<!--
In-depth description of the changes, especially if the changes are significant or complex.
-->
