### PR TITLE
fix_traffic_light_waypoints

### DIFF
--- a/waypoints/tsukuba/m2/traffic_light_Senior.yaml
+++ b/waypoints/tsukuba/m2/traffic_light_Senior.yaml
@@ -24,11 +24,12 @@ waypoints:
 - point: {x: 175.020057, y: -53.579229, z: 0.0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 175.437447, y: -58.614835, z: 0.0, vel: 1, rad: 0.8, stop: false}
 - point: {x: 175.929455, y: -65.689038, z: 0.0, vel: 1, rad: 0.8, stop: false}
-- point: {x: 176.471285, y: -75.158167, z: 0.0, vel: 1, rad: 0.8, stop: true}
-- point: {x: 176.780903, y: -83.440429, z: 0.0, vel: 1, rad: 0.8, stop: true}
+- point: {x: 176.393144, y: -72.684953, z: 0.0, vel: 1, rad: 0.5, stop: true}
+- point: {x: 176.752663, y: -80.893971, z: 0.0, vel: 1, rad: 0.5, stop: true}
 - point: {x: 177.503343, y: -91.206663, z: 0.0, vel: 1, rad: 0.8, stop: false}
+- point: {x: 177.310841, y: -99.996086, z: 0.0, vel: 1, rad: 0.5, stop: true}
 finish_pose:
   header: {seq: 0, stamp: 1663209268.6905353, frame_id: map}
   pose:
     position: {x: 179.454312, y: -98.267942, z: 0}
-    orientation: {x: 0.0, y: 0.0, z: 0.015300746884531077, w: 0.999882936720482}
+    orientation: {x: 0.0, y: 0.0, z: 0.015300746884531079, w: 0.999882936720482}


### PR DESCRIPTION
## PR Type
<!--
Please select the type of changes you're introducing to the codebase:
-->
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Overview
- 確認走行終了後→信号機までのwaypointsの修正. 
<!--
Brief summary of the changes made in this PR.
-->

## Detail
- 確認走行終了後から信号機までのwaypoinsに修正が必要な箇所があったため修正しました. 以下に修正箇所(具体的な修正内容)を示します. 

1. waypoint No.26が停止位置よりも奥に設定されていた. (waypoint No.26の位置修正)
2. waypoint No.27が道路上に設定されている可能性が高かった. (waypoint No.27の位置修正)
3. 1つ目の信号機を渡った後の停止位置のwaypointが設定されていなかった. (waypoint No.29を追加. )

- つくちゃれが発信しているYoutubeの動画を見てミスに気づいたため, 参考文献として一応置いておきます. 
(https://youtu.be/LxoUXeCZ-4E?si=PeJR0iNqeXShxe4p)

<!--
In-depth description of the changes, especially if the changes are significant or complex.
-->

## Attention
- 細かい部分は実際につくばで調整するとして, 11/3(金)の最初はこのwaypointsを用いて走らせていと考えています. 
- waypointsの調整をしただけなので特段気になることがなければMergeして頂けますと幸いです. 
<!--
Any particular attention or caution the reviewers should have regarding the PR.
-->
