### PR TITLE
fix_waypoints_before_stopping

### DIFF
--- a/multi_map/hosei/m2/courtyard/waypoints.yaml
+++ b/multi_map/hosei/m2/courtyard/waypoints.yaml
@@ -5,13 +5,16 @@ waypoints:
 - point: {x: 26.8631, y: -2.89797, z: 0, vel: 1, rad: 1, stop: false}
 - point: {x: 37.9027, y: -4.68808, z: 0, vel: 1, rad: 1, stop: false}
 - point: {x: 44.9846, y: -6.30966, z: 0, vel: 1, rad: 1, stop: true}
+- point: {x: 51.271607, y: -5.88035, z: 0.0, vel: 1, rad: 1, stop: false}
 - point: {x: 52.5925, y: -3.09705, z: 0, vel: 1, rad: 1, stop: true, change_map: 1}
 - point: {x: 52.565003, y: 1.28308, z: 0, vel: 1, rad: 1, stop: false}
 - point: {x: 52.194951, y: 9.672022, z: 0, vel: 1, rad: 1, stop: false}
 - point: {x: 51.80363, y: 18.453016, z: 0, vel: 1, rad: 1, stop: true}
 - point: {x: 51.081711, y: 26.259999, z: 0, vel: 1, rad: 1, stop: false}
 - point: {x: 50.398817, y: 35.470935, z: 0, vel: 1, rad: 1, stop: false}
-- point: {x: 48.62621842608204, y: 52.68264682230747, z: 0, vel: 1, rad: 1, stop: true, change_map: 2}
+- point: {x: 50.080661, y: 43.319406, z: 0.0, vel: 1, rad: 1, stop: false}
+- point: {x: 50.525958, y: 49.00931, z: 0.0, vel: 1, rad: 1, stop: false}
+- point: {x: 48.781878, y: 51.470812, z: 0, vel: 1, rad: 1, stop: true, change_map: 2}
 - point: {x: 46.520533, y: 52.485163, z: 0, vel: 1, rad: 1, stop: false}
 - point: {x: 42.753269, y: 52.479727, z: 0, vel: 1, rad: 1, stop: false}
 - point: {x: 39.068438, y: 52.473954, z: 0, vel: 1, rad: 1, stop: false}
@@ -21,7 +24,8 @@ waypoints:
 - point: {x: 20.317232, y: 52.097806, z: 0, vel: 1, rad: 1, stop: false}
 - point: {x: 15.718961, y: 51.940799, z: 0, vel: 1, rad: 1, stop: false}
 - point: {x: 10.973653, y: 51.854217, z: 0, vel: 1, rad: 1, stop: false}
-- point: {x: 6.199051, y: 51.574575, z: 0, vel: 1, rad: 1, stop: false}
+- point: {x: 6.097686, y: 52.436013, z: 0, vel: 1, rad: 1, stop: false}
+- point: {x: 3.649584, y: 51.705877, z: 0.0, vel: 1, rad: 1, stop: false}
 - point: {x: 3.092462763088358, y: 50.0782140910532, z: 0, vel: 1, rad: 1, stop: true, change_map: 3}
 - point: {x: 4.564803, y: 46.880181, z: 0, vel: 1, rad: 1, stop: false}
 - point: {x: 6.12692, y: 43.595238, z: 0, vel: 1, rad: 1, stop: false}
@@ -38,7 +42,8 @@ waypoints:
 - point: {x: 23.727268, y: 8.59853, z: 0, vel: 1, rad: 1, stop: false}
 - point: {x: 24.951236, y: 6.492353, z: 0, vel: 1, rad: 1, stop: false}
 - point: {x: 26.493958, y: 3.556276, z: 0, vel: 1, rad: 1, stop: false}
-- point: {x: 27.718266, y: 1.145423, z: 0, vel: 1, rad: 1, stop: true}
+- point: {x: 27.718266, y: 1.145423, z: 0, vel: 1, rad: 1, stop: false}
+- point: {x: 28.036114, y: -0.855299, z: 0.0, vel: 1, rad: 1, stop: false}
 - point: {x: 26.187749099509574, y: -1.7120549189990433, z: 0, vel: 1, rad: 1, stop: true, change_map: 4}
 - point: {x: 22.855537, y: -1.172101, z: 0, vel: 1, rad: 1, stop: false}
 - point: {x: 15.455097, y: -0.557871, z: 0, vel: 1, rad: 1, stop: false}

--- a/multi_map/tsukuba/m2/From_start_to_goal/waypoints.yaml
+++ b/multi_map/tsukuba/m2/From_start_to_goal/waypoints.yaml
@@ -112,6 +112,7 @@ waypoints:
 - point: {x: -237.175403, y: -0.54377, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: -237.984958, y: 4.443831, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: -239.028181, y: 11.457968, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
+- point: {x: -239.556422, y: 17.313128, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: -239.779581, y: 18.635611, z: 0.0, vel: 1.0, rad: 0.5, stop: true}
 - point: {x: -240.782779, y: 25.869867, z: 0.0, vel: 1.0, rad: 0.5, stop: true}
 - point: {x: -242.14426, y: 37.540707, z: 0.0, vel: 1, rad: 0.8, stop: false}

--- a/waypoints/tsukuba/m2/traffic_light_1_Senior.yaml
+++ b/waypoints/tsukuba/m2/traffic_light_1_Senior.yaml
@@ -34,4 +34,4 @@ finish_pose:
   header: {seq: 0, stamp: 1663209268.6905353, frame_id: map}
   pose:
     position: {x: 179.454312, y: -98.267942, z: 0}
-    orientation: {x: 0.0, y: 0.0, z: 0.015300746884531084, w: 0.999882936720482}
+    orientation: {x: 0.0, y: 0.0, z: 0.015300746884531083, w: 0.999882936720482}

--- a/waypoints/tsukuba/m2/traffic_light_1_Senior.yaml
+++ b/waypoints/tsukuba/m2/traffic_light_1_Senior.yaml
@@ -24,6 +24,7 @@ waypoints:
 - point: {x: 175.020057, y: -53.579229, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: 175.437447, y: -58.614835, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: 175.929455, y: -65.689038, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
+- point: {x: 176.059906, y: -71.737326, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: 176.117757, y: -72.903448, z: 0.0, vel: 1.0, rad: 0.5, stop: true}
 - point: {x: 176.552663, y: -80.193971, z: 0.0, vel: 1.0, rad: 0.5, stop: true}
 - point: {x: 177.240672, y: -94.852455, z: 0.0, vel: 1, rad: 1, stop: false}
@@ -33,4 +34,4 @@ finish_pose:
   header: {seq: 0, stamp: 1663209268.6905353, frame_id: map}
   pose:
     position: {x: 179.454312, y: -98.267942, z: 0}
-    orientation: {x: 0.0, y: 0.0, z: 0.015300746884531083, w: 0.999882936720482}
+    orientation: {x: 0.0, y: 0.0, z: 0.015300746884531084, w: 0.999882936720482}


### PR DESCRIPTION
## PR Type
<!--
Please select the type of changes you're introducing to the codebase:
-->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Overview
- stop位置の直前のwaypoints補正. 
<!--
Brief summary of the changes made in this PR.
-->

## Detail
- https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2/issues/74#issue-1977032068
- 停止するwaypointの次のwaypointが機体の横に出ている時に上記の問題が確認されるため, 停止する位置の一つ前のwaypointの位置を調整することで方向を合わせるのに時間がかかる問題を軽減しました. 
<!--
In-depth description of the changes, especially if the changes are significant or complex.
-->

## Test
- [x] 中庭内で検証した結果, 今回の補正によって方向を合わせるために時間がかかる問題は起こりませんでした. 
- つくばでも同様の効果を期待するため, つくばの方も補正しました.  
<!--
what was done to ensure it works.
Example:
- [ ] I have tested this change with gazebo
- [ ] I have tested this change with rosbag
-->
