### PR TITLE
Add/tandem waypoints

### DIFF
--- a/multi_map/tsukuba/m2/From_start_to_goal/waypoints.yaml
+++ b/multi_map/tsukuba/m2/From_start_to_goal/waypoints.yaml
@@ -10,22 +10,22 @@ waypoints:
 - point: {x: 62.485907, y: -6.143885, z: 0.0, vel: 1.0, rad: 1.5, stop: false}
 - point: {x: 64.910184, y: -11.818898, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: 68.877183, y: -12.590259, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
-- point: {x: 72.596244, y: -13.003488, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
+- point: {x: 72.596244, y: -13.003488, z: 0.0, vel: 1.0, rad: 0.8, stop: false, tandem_start: 1}
 - point: {x: 76.590792, y: -12.893293, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: 80.35213, y: -12.830639, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: 81.384249, y: -14.050335, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: 83.092262, y: -15.427765, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
-- point: {x: 85.375453, y: -15.573047, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
+- point: {x: 85.375453, y: -15.573047, z: 0.0, vel: 1.0, rad: 0.8, stop: false, tandem_end: 1}
 - point: {x: 87.948912, y: -15.646575, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: 90.475288, y: -16.639903, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: 93.450537, y: -16.998035, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: 96.921661, y: -17.631653, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: 100.375045, y: -19.617055, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
-- point: {x: 102.948505, y: -19.102363, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
+- point: {x: 102.948505, y: -19.102363, z: 0.0, vel: 1.0, rad: 0.8, stop: false, tandem_start: 2}
 - point: {x: 105.076101, y: -18.22123, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: 107.367264, y: -16.761175, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: 110.350672, y: -16.292848, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
-- point: {x: 113.796018, y: -17.659821, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
+- point: {x: 113.796018, y: -17.659821, z: 0.0, vel: 1.0, rad: 0.8, stop: false, tandem_end: 2}
 - point: {x: 114.18043, y: -24.026653, z: 0.0, vel: 1.0, rad: 1.5, stop: false}
 - point: {x: 114.746465, y: -31.45136, z: 0.0, vel: 1.0, rad: 1.5, stop: false}
 - point: {x: 115.333031, y: -39.141904, z: 0.0, vel: 1.0, rad: 1.5, stop: false}
@@ -46,7 +46,7 @@ waypoints:
 - point: {x: 76.616318, y: -88.087274, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: 72.632031, y: -88.347119, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: 68.777666, y: -88.390426, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
-- point: {x: 66.23661, y: -88.305365, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
+- point: {x: 66.23661, y: -88.305365, z: 0.0, vel: 1.0, rad: 0.8, stop: false, tandem_start: 3}
 - point: {x: 63.857635, y: -88.214003, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: 61.631433, y: -88.274038, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: 59.093886, y: -88.555987, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
@@ -60,7 +60,7 @@ waypoints:
 - point: {x: 37.217253, y: -90.258079, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: 34.229757, y: -90.482703, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: 33.060534, y: -92.847888, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
-- point: {x: 30.366349, y: -94.100997, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
+- point: {x: 30.366349, y: -94.100997, z: 0.0, vel: 1.0, rad: 0.8, stop: false, tandem_end: 3}
 - point: {x: 26.293743, y: -94.351619, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: 22.346447, y: -94.664897, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: 18.406542, y: -94.526527, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
@@ -79,9 +79,9 @@ waypoints:
 - point: {x: 3.148287, y: -28.898688, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: -2.730931, y: -28.585594, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: -7.116524, y: -28.652301, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
-- point: {x: -12.738496, y: -29.080464, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
+- point: {x: -12.738496, y: -29.080464, z: 0.0, vel: 1.0, rad: 0.8, stop: false, tandem_start: 4}
 - point: {x: -17.280751, y: -29.341085, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
-- point: {x: -22.895943, y: -29.85585, z: 0.0, vel: 1.0, rad: 0.8, stop: true}
+- point: {x: -22.895943, y: -29.85585, z: 0.0, vel: 1.0, rad: 0.8, stop: true, tandem_end: 4}
 - point: {x: -34.374714, y: -35.791904, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: -38.994835, y: -38.941986, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: -44.717484, y: -39.414498, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
@@ -107,13 +107,13 @@ waypoints:
 - point: {x: -232.988183, y: -26.22715, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: -233.909582, y: -21.018721, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: -234.574639, y: -15.97928, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
-- point: {x: -235.484173, y: -10.405274, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
+- point: {x: -235.484173, y: -10.405274, z: 0.0, vel: 1.0, rad: 0.8, stop: false, tandem_start: 5}
 - point: {x: -236.191603, y: -5.342143, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: -237.175403, y: -0.54377, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: -237.984958, y: 4.443831, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: -239.028181, y: 11.457968, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
 - point: {x: -239.556422, y: 17.313128, z: 0.0, vel: 1.0, rad: 0.8, stop: false}
-- point: {x: -239.779581, y: 18.635611, z: 0.0, vel: 1.0, rad: 0.5, stop: true}
+- point: {x: -239.779581, y: 18.635611, z: 0.0, vel: 1.0, rad: 0.5, stop: true, tandem_end: 5}
 - point: {x: -240.782779, y: 25.869867, z: 0.0, vel: 1.0, rad: 0.5, stop: true}
 - point: {x: -242.14426, y: 37.540707, z: 0.0, vel: 1, rad: 0.8, stop: false}
 - point: {x: -242.404303, y: 40.538045, z: 0.0, vel: 1, rad: 1, stop: false, change_map: 2}
@@ -275,10 +275,10 @@ waypoints:
 - point: {x: -360.558975, y: 45.227039, z: 0, vel: 1, rad: 1, stop: false}
 - point: {x: -360.686396, y: 39.197549, z: 0.0, vel: 1, rad: 1, stop: false}
 - point: {x: -361.971807, y: 33.280869, z: 0.0, vel: 1, rad: 1, stop: false}
-- point: {x: -363.277947, y: 28.849273, z: 0.0, vel: 1, rad: 1, stop: false}
+- point: {x: -363.277947, y: 28.849273, z: 0.0, vel: 1, rad: 1, stop: false, tandem_start: 6}
 - point: {x: -364.554463, y: 25.440328, z: 0, vel: 1, rad: 1, stop: false}
 - point: {x: -365.751713, y: 22.612242, z: 0.0, vel: 1, rad: 1, stop: false}
-- point: {x: -366.253041, y: 20.016411, z: 0, vel: 1, rad: 0.3, stop: true}
+- point: {x: -366.253041, y: 20.016411, z: 0, vel: 1, rad: 0.3, stop: true, tandem_end: 6}
 - point: {x: -366.78738, y: 13.957437, z: 0, vel: 1, rad: 0.3, stop: true}
 - point: {x: -369.191557, y: -0.084086, z: 0, vel: 1, rad: 1, stop: false}
 - point: {x: -373.435081, y: 0.228528, z: 0, vel: 1, rad: 0.3, stop: true}


### PR DESCRIPTION
## PR Type
<!--
Please select the type of changes you're introducing to the codebase:
-->
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Overview
- 確認走行〜信号機までのmulti_mapへのtandem追加. 
<!--
Brief summary of the changes made in this PR.
-->

## Detail
- つくちゃれ走行コースのmulti_map(kbkn_maps/maulti_map/tsukuba/m2/From_start_to_goal/waypoints.yaml)に以下の2つのルールでtandemを追加しました. 


1. 基本的に, 道が細くてロボットが通れない部分の手前にSTARTし, 広くなったらENDする. 

2. 一時停止位置の少し前にSTARTし, 一時停止の位置でENDする. 

 
- tandemの設定をするのが初めてなので経験者の方々にtandemの設定方法があっているのかや, 改善点などをご指摘いただきたいです. 

<!--
In-depth description of the changes, especially if the changes are significant or complex.
-->

## Attention
- このブランチはmainではなく, fix/waypoint_before_stoppingから切ったものであるため, 現在出しているPR(https://github.com/KBKN-Autonomous-Robotics-Lab/kbkn_maps/pull/26)とコンフリクトを起こす可能性があるため, 先にPR#26をご確認いただけますと幸いです. 

- 細かい部分はつくばで調整します. 
<!--
Any particular attention or caution the reviewers should have regarding the PR.
-->
